### PR TITLE
Add options to general config; change from rect to item bounding box

### DIFF
--- a/src/searchstims/config/classes.py
+++ b/src/searchstims/config/classes.py
@@ -118,7 +118,7 @@ class RectangleConfig:
         color of target. For RectangleConfig, default is 'green'.
     """
     item_bbox_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
-                                 default=(10, 30))
+                                 default=(30, 30))
     image_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
                          default=(227, 227))
     grid_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),

--- a/src/searchstims/config/classes.py
+++ b/src/searchstims/config/classes.py
@@ -126,7 +126,7 @@ class RectangleConfig:
     border_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
                           default=None)
     min_center_dist = attr.ib(validator=optional(instance_of(int)), default=None)
-    jitter = attr.ib(validator=instance_of(int), default=5)
+    jitter = attr.ib(validator=optional(instance_of(int)), default=5)
     target_color = attr.ib(validator=instance_of(str), default='red')
     distractor_color = attr.ib(validator=instance_of(str), default='green')
 
@@ -188,7 +188,7 @@ class NumberConfig:
     border_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
                           default=None)
     min_center_dist = attr.ib(validator=optional(instance_of(int)), default=None)
-    jitter = attr.ib(validator=instance_of(int), default=5)
+    jitter = attr.ib(validator=optional(instance_of(int)), default=5)
     target_color = attr.ib(validator=instance_of(str), default='white')
     distractor_color = attr.ib(validator=instance_of(str), default='white')
     target_number = attr.ib(validator=[instance_of(int), number_validator], default=2)

--- a/src/searchstims/config/classes.py
+++ b/src/searchstims/config/classes.py
@@ -3,6 +3,10 @@ import attr
 from attr.validators import instance_of, optional
 from attr import converters
 
+def check_len_is_two(instance, attribute, value):
+    if len(value) != 2:
+        raise ValueError(f"{attribute.name} tuple for {instance.name} should be two elements, got {value}")
+
 
 @attr.s
 class GeneralConfig:
@@ -36,12 +40,6 @@ class GeneralConfig:
     num_target_present = attr.ib(converter=converters.optional(int))
     num_target_absent = attr.ib(converter=converters.optional(int))
     set_sizes = attr.ib(validator=optional(instance_of(list)))
-
-
-# ----------------- validator functions used by RectangleConfig and NumberConfig ---------------------------------------
-def check_border_size(instance, attribute, value):
-    if len(value) != 2:
-        raise ValueError(f"border size tuple should be two elements, got {value}")
 
 
 @attr.s
@@ -80,25 +78,13 @@ class RectangleConfig:
     distractor_color : str
         color of target. For RectangleConfig, default is 'green'.
     """
-    rects_width_height = attr.ib(validator=instance_of(tuple), default=(10, 30))
-    @rects_width_height.validator
-    def check_rects_width_height(self, attribute, value):
-        if len(value) != 2:
-            raise ValueError(f"rects_width_height tuple should be two elements, got {value}")
-
-    image_size = attr.ib(validator=instance_of(tuple), default=(227, 227))
-    @image_size.validator
-    def check_image_size(self, attribute, value):
-        if len(value) != 2:
-            raise ValueError(f"image_size tuple should be two elements, got {value}")
-
-    grid_size = attr.ib(validator=instance_of(tuple), default=(5,5))
-    @grid_size.validator
-    def check_grid_size(self, attribute, value):
-        if len(value) != 2:
-            raise ValueError(f"grid size tuple should be two elements, got {value}")
-
-    border_size = attr.ib(validator=optional([instance_of(tuple), check_border_size]),
+    rects_width_height = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
+                                 default=(10, 30))
+    image_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
+                         default=(227, 227))
+    grid_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
+                        default=(5,5))
+    border_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
                           default=None)
     min_center_dist = attr.ib(validator=optional(instance_of(int)), default=None)
     jitter = attr.ib(validator=instance_of(int), default=5)
@@ -154,25 +140,13 @@ class NumberConfig:
     target_number : int
     distractor_number : int
     """
-    rects_width_height = attr.ib(validator=instance_of(tuple), default=(30, 30))
-    @rects_width_height.validator
-    def check_rects_width_height(self, attribute, value):
-        if len(value) != 2:
-            raise ValueError(f"rects_width_height tuple should be two elements, got {value}")
-
-    image_size = attr.ib(validator=instance_of(tuple), default=(227, 227))
-    @image_size.validator
-    def check_image_size(self, attribute, value):
-        if len(value) != 2:
-            raise ValueError(f"image_size tuple should be two elements, got {value}")
-
-    grid_size = attr.ib(validator=instance_of(tuple), default=(5,5))
-    @grid_size.validator
-    def check_grid_size(self, attribute, value):
-        if len(value) != 2:
-            raise ValueError(f"grid size tuple should be two elements, got {value}")
-
-    border_size = attr.ib(validator=optional([instance_of(tuple), check_border_size]),
+    rects_width_height = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
+                                 default=(30, 30))
+    image_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
+                         default=(227, 227))
+    grid_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
+                        default=(5,5))
+    border_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
                           default=None)
     min_center_dist = attr.ib(validator=optional(instance_of(int)), default=None)
     jitter = attr.ib(validator=instance_of(int), default=5)

--- a/src/searchstims/config/classes.py
+++ b/src/searchstims/config/classes.py
@@ -34,12 +34,51 @@ class GeneralConfig:
         If specified in this section and not specified in the section for a specific stimulus,
         then this value will be used. If specified in another section, that value overrides
         this one.
+
+    The remaining attributes, if declared as options and assigned values in the [GENERAL] section
+    of a config.ini file, will be used for all stimuli *unless* the same options are declared in
+    a section for a specific stimulus, in which case those values override the values assigned to
+    the attributes in the [GENERAL[ section (and thus the GeneralConfig instance that represents it).
+
+    rects_width_height : tuple
+        two element tuple, (width, height). The size of rectangles that contain
+        items (target + distractors) in the visual search stimulus.
+        In order of (width, height) because that's what PyGame expects.
+    image_size : tuple
+        two element tuple, (rows, columns). This will be the size of an input
+        to the neural network architecture that you're training.
+    grid_size : tuple
+        two element tuple, (rows, columns). Represents the "grid" that the
+        visuals search stimulus is divided into, where each cell in that
+        grid can contain an item (either the target or a distractor). The
+        total number of cells will be rows * columns.
+    border_size : tuple
+        two element tuple, (rows, columns). The size of the border between
+        the actual end of the image and the grid of cells within the image
+        that will contain the items (target + distractors).
+        Useful if you are worried about edge effects.
+    min_center_dist : int
+        minimum distance to maintain between the center of items.
+        Useful if you are worried about crowding effects.
+    jitter : int
+        maximum value of jitter applied to center points of items.
     """
     output_dir = attr.ib(validator=instance_of(str))
     json_filename = attr.ib(validator=instance_of(str))
     num_target_present = attr.ib(converter=converters.optional(int))
     num_target_absent = attr.ib(converter=converters.optional(int))
     set_sizes = attr.ib(validator=optional(instance_of(list)))
+
+    rects_width_height = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
+                                 default=None)
+    image_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
+                         default=None)
+    grid_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
+                        default=None)
+    border_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
+                          default=None)
+    min_center_dist = attr.ib(validator=optional(instance_of(int)), default=None)
+    jitter = attr.ib(validator=optional(instance_of(int)), default=None)
 
 
 @attr.s

--- a/src/searchstims/config/classes.py
+++ b/src/searchstims/config/classes.py
@@ -40,7 +40,7 @@ class GeneralConfig:
     a section for a specific stimulus, in which case those values override the values assigned to
     the attributes in the [GENERAL[ section (and thus the GeneralConfig instance that represents it).
 
-    rects_width_height : tuple
+    item_bbox_size : tuple
         two element tuple, (width, height). The size of rectangles that contain
         items (target + distractors) in the visual search stimulus.
         In order of (width, height) because that's what PyGame expects.
@@ -69,7 +69,7 @@ class GeneralConfig:
     num_target_absent = attr.ib(converter=converters.optional(int))
     set_sizes = attr.ib(validator=optional(instance_of(list)))
 
-    rects_width_height = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
+    item_bbox_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
                                  default=None)
     image_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
                          default=None)
@@ -87,7 +87,7 @@ class RectangleConfig:
 
     Attributes
     ----------
-    rects_width_height : tuple
+    item_bbox_size : tuple
         two element tuple, (width, height). The size of rectangles that contain
         items (target + distractors) in the visual search stimulus.
         For RectangleConfig this is literally the size of the rectangles that are
@@ -117,7 +117,7 @@ class RectangleConfig:
     distractor_color : str
         color of target. For RectangleConfig, default is 'green'.
     """
-    rects_width_height = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
+    item_bbox_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
                                  default=(10, 30))
     image_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
                          default=(227, 227))
@@ -148,7 +148,7 @@ class NumberConfig:
 
     Attributes
     ----------
-    rects_width_height : tuple
+    item_bbox_size : tuple
         two element tuple, (width, height). The size of rectangles that contain
         items (target + distractors) in the visual search stimulus.
         For NumberConfig this must be the size of the .png images that contain the
@@ -179,7 +179,7 @@ class NumberConfig:
     target_number : int
     distractor_number : int
     """
-    rects_width_height = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
+    item_bbox_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
                                  default=(30, 30))
     image_size = attr.ib(validator=optional([instance_of(tuple), check_len_is_two]),
                          default=(227, 227))

--- a/src/searchstims/config/classes.py
+++ b/src/searchstims/config/classes.py
@@ -41,11 +41,11 @@ class GeneralConfig:
     the attributes in the [GENERAL[ section (and thus the GeneralConfig instance that represents it).
 
     item_bbox_size : tuple
-        two element tuple, (width, height). The size of rectangles that contain
-        items (target + distractors) in the visual search stimulus.
+        two element tuple, (height, width). The size of the
+        "bounding box" that contains items (target + distractors) in the visual search stimulus.
         In order of (width, height) because that's what PyGame expects.
     image_size : tuple
-        two element tuple, (rows, columns). This will be the size of an input
+        two element tuple, (height, width). This will be the size of an input
         to the neural network architecture that you're training.
     grid_size : tuple
         two element tuple, (rows, columns). Represents the "grid" that the
@@ -53,7 +53,7 @@ class GeneralConfig:
         grid can contain an item (either the target or a distractor). The
         total number of cells will be rows * columns.
     border_size : tuple
-        two element tuple, (rows, columns). The size of the border between
+        two element tuple, (height, width). The size of the border between
         the actual end of the image and the grid of cells within the image
         that will contain the items (target + distractors).
         Useful if you are worried about edge effects.
@@ -88,13 +88,10 @@ class RectangleConfig:
     Attributes
     ----------
     item_bbox_size : tuple
-        two element tuple, (width, height). The size of rectangles that contain
-        items (target + distractors) in the visual search stimulus.
-        For RectangleConfig this is literally the size of the rectangles that are
-        displayed on the visual search stimulus. Default is (10, 30).
-        In order of (width, height) because that's what PyGame expects.
+        two element tuple, (height, width). The size of the
+        "bounding box" that contains items (target + distractors) in the visual search stimulus.
     image_size : tuple
-        two element tuple, (rows, columns). This will be the size of an input
+        two element tuple, (height, width). This will be the size of an input
         to the neural network architecture that you're training.
     grid_size : tuple
         two element tuple, (rows, columns). Represents the "grid" that the
@@ -102,7 +99,7 @@ class RectangleConfig:
         grid can contain an item (either the target or a distractor). The
         total number of cells will be rows * columns.
     border_size : tuple
-        two element tuple, (rows, columns). The size of the border between
+        two element tuple, (height, width). The size of the border between
         the actual end of the image and the grid of cells within the image
         that will contain the items (target + distractors).
         Optional; default is None. Useful if you are worried about edge effects.
@@ -112,6 +109,9 @@ class RectangleConfig:
         Optional; default is None.
     jitter : int
         maximum value of jitter applied to center points of items. Default is 5.
+    rectangle_size : tuple
+        two element tuple, (height, width). The size of the rectangle plotted
+        inside the item bounding box. Default is (10, 30).
     target_color : str
         color of target. For RectangleConfig, default is 'red'.
     distractor_color : str
@@ -149,13 +149,12 @@ class NumberConfig:
     Attributes
     ----------
     item_bbox_size : tuple
-        two element tuple, (width, height). The size of rectangles that contain
-        items (target + distractors) in the visual search stimulus.
+        two element tuple, (height, width). The size of the
+        "bounding box" that contains items (target + distractors) in the visual search stimulus.
         For NumberConfig this must be the size of the .png images that contain the
         number shapes, (30, 30).
-        In order of (width, height) because that's what PyGame expects.
     image_size : tuple
-        two element tuple, (rows, columns). This will be the size of an input
+        two element tuple, (height, width). This will be the size of an input
         to the neural network architecture that you're training.
     grid_size : tuple
         two element tuple, (rows, columns). Represents the "grid" that the
@@ -163,7 +162,7 @@ class NumberConfig:
         grid can contain an item (either the target or a distractor). The
         total number of cells will be rows * columns.
     border_size : tuple
-        two element tuple, (rows, columns). The size of the border between
+        two element tuple, (height, width). The size of the border between
         the actual end of the image and the grid of cells within the image
         that will contain the items (target + distractors).
         Optional; default is None. Useful if you are worried about edge effects.

--- a/src/searchstims/config/default.ini
+++ b/src/searchstims/config/default.ini
@@ -5,14 +5,14 @@ set_sizes = [1, 2, 4, 6, 8]
 output_dir = ./searchstims_output
 json_filename = filenames_by_set_size_and_target.json
 
-rects_width_height = (30, 30)
+item_bbox_size = (30, 30)
 image_size = (227, 227)
 border_size = None
 grid_size = (5, 5)
 jitter = 5
 
 [rectangle]
-rects_width_height = None
+item_bbox_size = None
 image_size = None
 border_size = None
 grid_size = None
@@ -23,7 +23,7 @@ target_color = red
 distractor_color = green
 
 [number]
-rects_width_height = None
+item_bbox_size = None
 image_size = None
 border_size = None
 grid_size = None

--- a/src/searchstims/config/default.ini
+++ b/src/searchstims/config/default.ini
@@ -5,24 +5,33 @@ set_sizes = [1, 2, 4, 6, 8]
 output_dir = ./searchstims_output
 json_filename = filenames_by_set_size_and_target.json
 
-[rectangle]
-rects_width_height = (10, 30)
-image_size = (227, 227)
-border_size = None
-grid_size = (5, 5)
-min_center_dist = None
-jitter = 5
-target_color = red
-distractor_color = green
-
-[number]
 rects_width_height = (30, 30)
 image_size = (227, 227)
 border_size = None
 grid_size = (5, 5)
-min_center_dist = None
 jitter = 5
+
+[rectangle]
+rects_width_height = None
+image_size = None
+border_size = None
+grid_size = None
+min_center_dist = None
+jitter = None
+
+target_color = red
+distractor_color = green
+
+[number]
+rects_width_height = None
+image_size = None
+border_size = None
+grid_size = None
+min_center_dist = None
+jitter = None
+
 target_color = white
 distractor_color = white
+
 target_number = 2
 distractor_number = 5

--- a/src/searchstims/config/types.ini
+++ b/src/searchstims/config/types.ini
@@ -5,6 +5,13 @@ set_sizes = list
 output_dir = str
 json_filename = str
 
+rects_width_height = tuple
+image_size = tuple
+border_size = tuple
+grid_size = tuple
+min_center_dist = int
+jitter = int
+
 [rectangle]
 rects_width_height = tuple
 image_size = tuple
@@ -12,6 +19,7 @@ border_size = tuple
 grid_size = tuple
 min_center_dist = int
 jitter = int
+
 target_color = str
 distractor_color = str
 
@@ -22,7 +30,9 @@ border_size = tuple
 grid_size = tuple
 min_center_dist = int
 jitter = int
+
 target_color = str
 distractor_color = str
+
 target_number = int
 distractor_number = int

--- a/src/searchstims/config/types.ini
+++ b/src/searchstims/config/types.ini
@@ -5,7 +5,7 @@ set_sizes = list
 output_dir = str
 json_filename = str
 
-rects_width_height = tuple
+item_bbox_size = tuple
 image_size = tuple
 border_size = tuple
 grid_size = tuple
@@ -13,7 +13,7 @@ min_center_dist = int
 jitter = int
 
 [rectangle]
-rects_width_height = tuple
+item_bbox_size = tuple
 image_size = tuple
 border_size = tuple
 grid_size = tuple
@@ -24,7 +24,7 @@ target_color = str
 distractor_color = str
 
 [number]
-rects_width_height = tuple
+item_bbox_size = tuple
 image_size = tuple
 border_size = tuple
 grid_size = tuple

--- a/src/searchstims/make.py
+++ b/src/searchstims/make.py
@@ -9,6 +9,24 @@ VALID_STIM_SECTIONS = [
     'number'
 ]
 
+COMMON_ARGS = [
+        'image_size',
+        'border_size',
+        'grid_size',
+        'min_center_dist',
+        'rects_width_height',
+        'jitter',
+]
+
+def _get_common_args_from_stim_or_general(stim_config, general_config):
+    common_args = []
+    for this_attr in COMMON_ARGS:
+        this_arg = getattr(stim_config, this_attr)
+        if this_arg is None:
+            this_arg = getattr(general_config, this_attr)
+        common_args.append(this_arg)
+    return tuple(common_args)
+
 
 def make(config_obj):
     """actual function that makes all the stimuli
@@ -87,25 +105,29 @@ def make(config_obj):
         if getattr(config_obj, section) is not None:
             if section == 'rectangle':
                 stim_config = config_obj.rectangle
+                (image_size, border_size, grid_size, min_center_dist,
+                 rects_width_height, jitter) = _get_common_args_from_stim_or_general(stim_config, general_config)
                 stim_maker = stim_makers.RectangleStimMaker(target_color=stim_config.target_color,
                                                             distractor_color=stim_config.distractor_color,
-                                                            window_size=stim_config.image_size,
-                                                            border_size=stim_config.border_size,
-                                                            grid_size=stim_config.grid_size,
-                                                            min_center_dist=stim_config.min_center_dist,
-                                                            rects_width_height=stim_config.rects_width_height,
-                                                            jitter=stim_config.jitter
+                                                            window_size=image_size,
+                                                            border_size=border_size,
+                                                            grid_size=grid_size,
+                                                            min_center_dist=min_center_dist,
+                                                            rects_width_height=rects_width_height,
+                                                            jitter=jitter
                                                             )
             elif section == 'number':
                 stim_config = config_obj.number
+                (image_size, border_size, grid_size, min_center_dist,
+                 rects_width_height, jitter) = _get_common_args_from_stim_or_general(stim_config, general_config)
                 stim_maker = stim_makers.NumberStimMaker(target_color=stim_config.target_color,
                                                          distractor_color=stim_config.distractor_color,
-                                                         window_size=stim_config.image_size,
-                                                         border_size=stim_config.border_size,
-                                                         grid_size=stim_config.grid_size,
-                                                         min_center_dist=stim_config.min_center_dist,
-                                                         rects_width_height=stim_config.rects_width_height,
-                                                         jitter=stim_config.jitter,
+                                                         window_size=image_size,
+                                                         border_size=border_size,
+                                                         grid_size=grid_size,
+                                                         min_center_dist=min_center_dist,
+                                                         rects_width_height=rects_width_height,
+                                                         jitter=jitter,
                                                          target_number=stim_config.target_number,
                                                          distractor_number=stim_config.distractor_number
                                                          )

--- a/src/searchstims/make.py
+++ b/src/searchstims/make.py
@@ -86,28 +86,28 @@ def make(config_obj):
     for section in VALID_STIM_SECTIONS:
         if getattr(config_obj, section) is not None:
             if section == 'rectangle':
-                init_config = config_obj.rectangle
-                stim_maker = stim_makers.RectangleStimMaker(target_color=init_config.target_color,
-                                                            distractor_color=init_config.distractor_color,
-                                                            window_size=init_config.image_size,
-                                                            border_size=init_config.border_size,
-                                                            grid_size=init_config.grid_size,
-                                                            min_center_dist=init_config.min_center_dist,
-                                                            rects_width_height=init_config.rects_width_height,
-                                                            jitter=init_config.jitter
+                stim_config = config_obj.rectangle
+                stim_maker = stim_makers.RectangleStimMaker(target_color=stim_config.target_color,
+                                                            distractor_color=stim_config.distractor_color,
+                                                            window_size=stim_config.image_size,
+                                                            border_size=stim_config.border_size,
+                                                            grid_size=stim_config.grid_size,
+                                                            min_center_dist=stim_config.min_center_dist,
+                                                            rects_width_height=stim_config.rects_width_height,
+                                                            jitter=stim_config.jitter
                                                             )
             elif section == 'number':
-                init_config = config_obj.number
-                stim_maker = stim_makers.NumberStimMaker(target_color=init_config.target_color,
-                                                         distractor_color=init_config.distractor_color,
-                                                         window_size=init_config.image_size,
-                                                         border_size=init_config.border_size,
-                                                         grid_size=init_config.grid_size,
-                                                         min_center_dist=init_config.min_center_dist,
-                                                         rects_width_height=init_config.rects_width_height,
-                                                         jitter=init_config.jitter,
-                                                         target_number=init_config.target_number,
-                                                         distractor_number=init_config.distractor_number
+                stim_config = config_obj.number
+                stim_maker = stim_makers.NumberStimMaker(target_color=stim_config.target_color,
+                                                         distractor_color=stim_config.distractor_color,
+                                                         window_size=stim_config.image_size,
+                                                         border_size=stim_config.border_size,
+                                                         grid_size=stim_config.grid_size,
+                                                         min_center_dist=stim_config.min_center_dist,
+                                                         rects_width_height=stim_config.rects_width_height,
+                                                         jitter=stim_config.jitter,
+                                                         target_number=stim_config.target_number,
+                                                         distractor_number=stim_config.distractor_number
                                                          )
             this_section_output_dir = os.path.join(root_output_dir, section)
 

--- a/src/searchstims/make.py
+++ b/src/searchstims/make.py
@@ -14,7 +14,7 @@ COMMON_ARGS = [
         'border_size',
         'grid_size',
         'min_center_dist',
-        'rects_width_height',
+        'item_bbox_size',
         'jitter',
 ]
 
@@ -101,32 +101,34 @@ def make(config_obj):
     # e.g. fnames_set_size_8_target_present = [stim_info['filename'] for stim_info in out_dict[8]['present']]
     out_dict = {}
 
+    # import pdb;pdb.set_trace()
+
     for section in VALID_STIM_SECTIONS:
         if getattr(config_obj, section) is not None:
             if section == 'rectangle':
                 stim_config = config_obj.rectangle
                 (image_size, border_size, grid_size, min_center_dist,
-                 rects_width_height, jitter) = _get_common_args_from_stim_or_general(stim_config, general_config)
+                 item_bbox_size, jitter) = _get_common_args_from_stim_or_general(stim_config, general_config)
                 stim_maker = stim_makers.RectangleStimMaker(target_color=stim_config.target_color,
                                                             distractor_color=stim_config.distractor_color,
                                                             window_size=image_size,
                                                             border_size=border_size,
                                                             grid_size=grid_size,
                                                             min_center_dist=min_center_dist,
-                                                            rects_width_height=rects_width_height,
+                                                            item_bbox_size=item_bbox_size,
                                                             jitter=jitter
                                                             )
             elif section == 'number':
                 stim_config = config_obj.number
                 (image_size, border_size, grid_size, min_center_dist,
-                 rects_width_height, jitter) = _get_common_args_from_stim_or_general(stim_config, general_config)
+                 item_bbox_size, jitter) = _get_common_args_from_stim_or_general(stim_config, general_config)
                 stim_maker = stim_makers.NumberStimMaker(target_color=stim_config.target_color,
                                                          distractor_color=stim_config.distractor_color,
                                                          window_size=image_size,
                                                          border_size=border_size,
                                                          grid_size=grid_size,
                                                          min_center_dist=min_center_dist,
-                                                         rects_width_height=rects_width_height,
+                                                         item_bbox_size=item_bbox_size,
                                                          jitter=jitter,
                                                          target_number=stim_config.target_number,
                                                          distractor_number=stim_config.distractor_number

--- a/src/searchstims/stim_makers.py
+++ b/src/searchstims/stim_makers.py
@@ -287,7 +287,6 @@ class AbstractStimMaker:
         display_surface.fill(colors_dict['black'])
         target_inds = np.random.choice(np.arange(set_size),
                                        size=num_target).tolist()
-        rects = []
         target_indices = []
         distractor_indices = []
         if self.grid_size:
@@ -297,10 +296,10 @@ class AbstractStimMaker:
 
         for item in range(set_size):
             # notice we are now using PyGame order of sizes, (width, height)
-            rect_tuple = (0, 0) + (self.item_bbox_size[1], self.item_bbox_size[0])
-            rect_to_draw = Rect(rect_tuple)
+            item_bbox_tuple = (0, 0) + (self.item_bbox_size[1], self.item_bbox_size[0])
+            item_bbox = Rect(item_bbox_tuple)
             center = (int(xx_to_use_ctr[item]), int(yy_to_use_ctr[item]))
-            rect_to_draw.center = center
+            item_bbox.center = center
             if item in target_inds:
                 is_target = True
                 target_indices.append(center)
@@ -311,10 +310,9 @@ class AbstractStimMaker:
                 distractor_indices.append(center)
                 if self.grid_size:
                     grid_as_char[cells_to_use[item]] = 'd'
-            curr_rect = self._return_rect_for_stim(display_surface=display_surface,
-                                                   rect_to_draw=rect_to_draw,
-                                                   is_target=is_target)
-            rects.append(curr_rect)
+            self.draw_item(display_surface=display_surface,
+                           item_bbox=item_bbox,
+                           is_target=is_target)
 
         if self.grid_size:
             grid_as_char = np.asarray(grid_as_char).reshape(self.grid_size[0], self.grid_size[1]).tolist()

--- a/src/searchstims/stim_makers.py
+++ b/src/searchstims/stim_makers.py
@@ -45,7 +45,7 @@ class AbstractStimMaker:
                  border_size=None,
                  grid_size=(5, 5),
                  min_center_dist=None,
-                 rects_width_height=(10, 30),
+                 item_bbox_size=(10, 30),
                  jitter=5):
         """__init__ function for Stim Makers
 
@@ -68,7 +68,7 @@ class AbstractStimMaker:
             Minimum distance between center point of items. Default is None, in
             which case any distance is permitted. Only used if grid_size is None
             and items are placed randomly instead of on a grid.
-        rects_width_height : tuple
+        item_bbox_size : tuple
             shape of pygame Rect objects that will be plotted,
             (width, height) in pixels. Default is (10, 30).
         jitter : int
@@ -92,7 +92,7 @@ class AbstractStimMaker:
         self.min_center_dist = min_center_dist
         self.window_size = window_size
         self.border_size = border_size
-        self.rects_width_height = rects_width_height
+        self.item_bbox_size = item_bbox_size
         self.jitter = jitter
 
     def _return_rect_for_stim(self, display_surface, rect_to_draw, is_target):
@@ -200,17 +200,17 @@ class AbstractStimMaker:
 
         else:  # if self.grid_size is None
             if self.border_size:
-                xx = np.arange(self.border_size[0] + (self.rects_width_height[1] / 2),
-                               self.window_size[0] - (self.border_size[0] + (self.rects_width_height[1] / 2) + 1),
+                xx = np.arange(self.border_size[0] + (self.item_bbox_size[1] / 2),
+                               self.window_size[0] - (self.border_size[0] + (self.item_bbox_size[1] / 2) + 1),
                                dtype=int)
-                yy = np.arange(self.border_size[1] + (self.rects_width_height[1] / 2),
-                               self.window_size[1] - (self.border_size[1] + (self.rects_width_height[1] / 2) + 1),
+                yy = np.arange(self.border_size[1] + (self.item_bbox_size[1] / 2),
+                               self.window_size[1] - (self.border_size[1] + (self.item_bbox_size[1] / 2) + 1),
                                dtype=int)
             else:
-                xx = np.arange(self.rects_width_height[1] / 2,
-                               self.window_size[0] - (self.rects_width_height[1] / 2))
-                yy = np.arange(self.rects_width_height[1] / 2,
-                               self.window_size[1] - (self.rects_width_height[1] / 2))
+                xx = np.arange(self.item_bbox_size[1] / 2,
+                               self.window_size[0] - (self.item_bbox_size[1] / 2))
+                yy = np.arange(self.item_bbox_size[1] / 2,
+                               self.window_size[1] - (self.item_bbox_size[1] / 2))
 
             # draw center points at random
             dists_are_good = False
@@ -279,7 +279,7 @@ class AbstractStimMaker:
             grid_as_char = None
 
         for item in range(set_size):
-            rect_tuple = (0, 0) + self.rects_width_height
+            rect_tuple = (0, 0) + self.item_bbox_size
             rect_to_draw = Rect(rect_tuple)
             center = (int(xx_to_use_ctr[item]), int(yy_to_use_ctr[item]))
             rect_to_draw.center = center
@@ -342,7 +342,7 @@ class NumberStimMaker(AbstractStimMaker):
                  min_center_dist=None,
                  window_size=(227, 227),
                  border_size=None,
-                 rects_width_height=(30, 30),
+                 item_bbox_size=(30, 30),
                  jitter=5,
                  target_number=2,
                  distractor_number=5):
@@ -362,7 +362,7 @@ class NumberStimMaker(AbstractStimMaker):
                          border_size=border_size,
                          grid_size=grid_size,
                          min_center_dist=min_center_dist,
-                         rects_width_height=rects_width_height,
+                         item_bbox_size=item_bbox_size,
                          jitter=jitter)
         self.target_number = target_number
         self.distractor_number = distractor_number

--- a/src/searchstims/stim_makers.py
+++ b/src/searchstims/stim_makers.py
@@ -328,13 +328,13 @@ class RectangleStimMaker(AbstractStimMaker):
     """Make visual search stimuli with vertical rectangles
     where target is different color form distractor.
     Considered a stimulus that allows for 'efficient' search."""
-    def _return_rect_for_stim(self, display_surface, rect_to_draw, is_target):
+    def draw_item(self, display_surface, item_bbox, is_target):
         if is_target:
             color = self.target_color
         else:
             color = self.distractor_color
-        rect = pygame.draw.rect(display_surface, colors_dict[color], rect_to_draw)
-        return rect
+        pygame.draw.rect(display_surface, colors_dict[color], item_bbox)
+
 
 
 class NumberStimMaker(AbstractStimMaker):

--- a/src/searchstims/stim_makers.py
+++ b/src/searchstims/stim_makers.py
@@ -95,10 +95,21 @@ class AbstractStimMaker:
         self.item_bbox_size = item_bbox_size
         self.jitter = jitter
 
-    def _return_rect_for_stim(self, display_surface, rect_to_draw, is_target):
-        """this function must return a pygame.rect object
-        which the StimMaker.make_stim method will `blit` on
-        the stimulus."""
+    def draw_item(self, display_surface, item_bbox, is_target):
+        """draw item for visual search stimulus
+
+        Parameters
+        ----------
+        display_surface : pygame.Surface
+        item_bbox : pygame.rect
+            item bounding box. The actual item is drawn
+            *within* this bounding box.
+        is_target : bool
+            if True, item to be drawn is a target.
+            if False, item to be drawn is a distractor.
+            How the item is drawn (color, orientation, shape, etc.) will
+            depend on whether this is True or False
+        """
         raise NotImplementedError
 
     def make_stim(self,

--- a/src/searchstims/stim_makers.py
+++ b/src/searchstims/stim_makers.py
@@ -391,10 +391,9 @@ class NumberStimMaker(AbstractStimMaker):
                                                               self.distractor_color)])
         self.distractor = pygame.image.load(self.distractor_png)
 
-    def _return_rect_for_stim(self, display_surface, rect_to_draw, is_target):
+    def draw_item(self, display_surface, item_bbox, is_target):
         """Returns target or distractor"""
         if is_target:
-            rect = display_surface.blit(self.target, rect_to_draw)
+            display_surface.blit(self.target, item_bbox)
         else:
-            rect = display_surface.blit(self.distractor, rect_to_draw)
-        return rect
+            display_surface.blit(self.distractor, item_bbox)

--- a/src/searchstims/stim_makers.py
+++ b/src/searchstims/stim_makers.py
@@ -326,14 +326,36 @@ class AbstractStimMaker:
 
 class RectangleStimMaker(AbstractStimMaker):
     """Make visual search stimuli with vertical rectangles
-    where target is different color form distractor.
-    Considered a stimulus that allows for 'efficient' search."""
+    where target is different color form distractor."""
     def draw_item(self, display_surface, item_bbox, is_target):
+        """Draws a vertical rectangle that is 1/3 the width of the item bounding box.
+
+        Parameters
+        ----------
+        display_surface : pygame.Surface
+            instance of Surface on which to draw item
+        item_bbox : pygame.Rect
+            instance of Rect that represents 'bounding box' within which
+            item should be drawn.
+        is_target : bool
+            if True, item to draw is target and target color should be used
+
+        Returns
+        -------
+        None
+        """
         if is_target:
             color = self.target_color
         else:
             color = self.distractor_color
-        pygame.draw.rect(display_surface, colors_dict[color], item_bbox)
+        rect_to_draw = item_bbox  # yes, they point to the same object
+
+        width = rect_to_draw.width
+        width = width // 3
+        rect_to_draw.width = width
+        rect_to_draw.left = rect_to_draw.left + width
+
+        pygame.draw.rect(display_surface, colors_dict[color], rect_to_draw)
 
 
 

--- a/src/searchstims/stim_makers.py
+++ b/src/searchstims/stim_makers.py
@@ -63,13 +63,13 @@ class AbstractStimMaker:
             Default is None.
         grid_size : tuple
             of length two, representing the number of (rows, columns)
-            in the grid on which tareget and distractors will be located.
+            in the grid on which target and distractors will be located.
         min_center_dist : int
             Minimum distance between center point of items. Default is None, in
             which case any distance is permitted. Only used if grid_size is None
             and items are placed randomly instead of on a grid.
         item_bbox_size : tuple
-            shape of pygame Rect objects that will be plotted,
+            shape of "bounding box" that contains items to be plotted,
             (height, width) in pixels. Default is (30, 30).
         jitter : int
             number of pixels to jitter each 'item' in the 'set'

--- a/tests/test_data/configs/test_config_feature_spatial_vgg16.ini
+++ b/tests/test_data/configs/test_config_feature_spatial_vgg16.ini
@@ -6,7 +6,7 @@ output_dir = ../visual_search_stimuli/searchstims_feature_spatial_vgg16
 json_filename = feature_spatial.json
 
 [rectangle]
-item_bbox_size = (30, 10)
+item_bbox_size = (30, 30)
 image_size = (224, 224)
 border_size = (30, 30)
 

--- a/tests/test_data/configs/test_config_feature_spatial_vgg16.ini
+++ b/tests/test_data/configs/test_config_feature_spatial_vgg16.ini
@@ -6,7 +6,7 @@ output_dir = ../visual_search_stimuli/searchstims_feature_spatial_vgg16
 json_filename = feature_spatial.json
 
 [rectangle]
-item_bbox_size = (10,30)
+item_bbox_size = (30, 10)
 image_size = (224, 224)
 border_size = (30, 30)
 

--- a/tests/test_data/configs/test_config_general_has_common_stim_options.ini
+++ b/tests/test_data/configs/test_config_general_has_common_stim_options.ini
@@ -5,7 +5,7 @@ set_sizes = [1, 2, 4, 8]
 output_dir = ../visual_search_stimuli/searchstims_feature_spatial_vgg16
 json_filename = feature_spatial.json
 
-item_bbox_size = (10,30)
+item_bbox_size = (30,30)
 image_size = (224, 224)
 border_size = (30, 30)
 

--- a/tests/test_data/configs/test_config_general_has_common_stim_options.ini
+++ b/tests/test_data/configs/test_config_general_has_common_stim_options.ini
@@ -5,12 +5,14 @@ set_sizes = [1, 2, 4, 8]
 output_dir = ../visual_search_stimuli/searchstims_feature_spatial_vgg16
 json_filename = feature_spatial.json
 
-[rectangle]
 item_bbox_size = (10,30)
 image_size = (224, 224)
 border_size = (30, 30)
 
+[rectangle]
+target_color = red
+distractor_color = green
+
 [number]
-item_bbox_size = (30,30)
-image_size = (224, 224)
-border_size = (30, 30)
+target_number = 2
+distractor_number = 5

--- a/tests/test_data/configs/test_number_config.ini
+++ b/tests/test_data/configs/test_number_config.ini
@@ -8,4 +8,4 @@ json_filename = filenames_by_set_size_and_target.json
 [number]
 # number uses 30x30 pixel .png files so this size
 # currently needs to stay constant
-rects_width_height = (30,30)
+item_bbox_size = (30,30)

--- a/tests/test_data/configs/test_rectangle_config.ini
+++ b/tests/test_data/configs/test_rectangle_config.ini
@@ -6,4 +6,4 @@ output_dir = ~/output
 json_filename = filenames_by_set_size_and_target.json
 
 [rectangle]
-item_bbox_size = (30, 10)
+item_bbox_size = (30, 30)

--- a/tests/test_data/configs/test_rectangle_config.ini
+++ b/tests/test_data/configs/test_rectangle_config.ini
@@ -6,4 +6,4 @@ output_dir = ~/output
 json_filename = filenames_by_set_size_and_target.json
 
 [rectangle]
-item_bbox_size = (10,30)
+item_bbox_size = (30, 10)

--- a/tests/test_data/configs/test_rectangle_config.ini
+++ b/tests/test_data/configs/test_rectangle_config.ini
@@ -6,4 +6,4 @@ output_dir = ~/output
 json_filename = filenames_by_set_size_and_target.json
 
 [rectangle]
-rects_width_height = (10,30)
+item_bbox_size = (10,30)


### PR DESCRIPTION
- possible to specify options that are common to all stimuli in [GENERAL] section
of config.ini file
  + e.g., image_size, item_bbox_size, jitter, grid_size
  + if one of these options is also specified in a section for a specific stimulus,
  that value overrides the one specified in the general section

- user specifies an item bounding box for items in stimulus, instead of 'rect'
  + the actual item is drawn within this "bounding box"
  + would make it possible to draw items with different sizes but same shape
- user specifies sizes in order of (height, width)
  + since people feeding images to neural networks are used to this order
  + even though PyGame expects (width, height)