### PR TITLE
BUG: fix args that `main` passes to `make`, fixes #17

### DIFF
--- a/src/searchstims/main.py
+++ b/src/searchstims/main.py
@@ -117,7 +117,7 @@ def main():
     stim_dict = _get_stim_dict(config)
     make(root_output_dir=config.general.output_dir,
          stim_dict=stim_dict,
-         json_filename=config.general.json_filename,
+         csv_filename=config.general.csv_filename,
          num_target_present=config.general.num_target_present,
          num_target_absent=config.general.num_target_absent,
          set_sizes=config.general.set_sizes)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+from .fixtures import *

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,2 @@
+from .configs import *
+from .paths import *

--- a/tests/fixtures/configs.py
+++ b/tests/fixtures/configs.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture
+def configs_root(data_for_tests_root):
+    return data_for_tests_root / 'configs'
+
+
+@pytest.fixture
+def two_v_five_config_path(configs_root):
+    return configs_root / 'test_2_v_5_config.ini'

--- a/tests/fixtures/paths.py
+++ b/tests/fixtures/paths.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).parent
+
+
+@pytest.fixture
+def data_for_tests_root():
+    return HERE / '..' / 'test_data'

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,14 @@
+import os
+
+
+CONSOLE_SCRIPT_NAME = 'searchstims'
+
+
+def test_console_script_help():
+    exit_status = os.system(f'{CONSOLE_SCRIPT_NAME} --help')
+    assert exit_status == 0
+
+
+def test_console_script(two_v_five_config_path):
+    exit_status = os.system(f'{CONSOLE_SCRIPT_NAME} {two_v_five_config_path}')
+    assert exit_status == 0


### PR DESCRIPTION
fixes argument that `main` passes to `make`, and also
adds unit tests that make sure the console script
actually works, which would have caught
that there was this mismatch.

- BUG: make `main` pass `csv_filename` to `make`
  instead of `json_filename`
- TST: add tests for console script / cli
  + add tests/fixtures
  + add tests/conftest.py that imports fixtures
  + add tests/test_scripts.py with tests for console script