### PR TITLE
ENH: add Pascal VOC annotations, fix #15

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -152,6 +152,28 @@ qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
 testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<6.0.0)"]
 
 [[package]]
+name = "jinja2"
+version = "3.0.1"
+description = "A very fast and expressive template engine."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "markupsafe"
+version = "2.0.1"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "matplotlib-inline"
 version = "0.1.2"
 description = "Inline Matplotlib backend for Jupyter"
@@ -371,7 +393,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">3.7, <3.10"
-content-hash = "8885fc8ce16aea0db41c84a2822e9f4e6bb9bb7d99d3b27c4e68483eacf0b74a"
+content-hash = "11ab29ac3fc440a3e0509ffc2e47fbeb0d54e00636bbf2b996f581231824feb4"
 
 [metadata.files]
 appnope = [
@@ -421,6 +443,46 @@ ipython-genutils = [
 jedi = [
     {file = "jedi-0.18.0-py2.py3-none-any.whl", hash = "sha256:18456d83f65f400ab0c2d3319e48520420ef43b23a086fdc05dff34132f0fb93"},
     {file = "jedi-0.18.0.tar.gz", hash = "sha256:92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707"},
+]
+jinja2 = [
+    {file = "Jinja2-3.0.1-py3-none-any.whl", hash = "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4"},
+    {file = "Jinja2-3.0.1.tar.gz", hash = "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"},
+]
+markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
+    {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
 ]
 matplotlib-inline = [
     {file = "matplotlib-inline-0.1.2.tar.gz", hash = "sha256:f41d5ff73c9f5385775d5c0bc13b424535c8402fe70ea8210f93e11f3683993e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ numpy = "^1.21.0"
 scipy = "^1.7.0"
 imageio = "^2.9.0"
 attrs = "^21.2.0"
+Jinja2 = "^3.0.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"

--- a/src/searchstims/make.py
+++ b/src/searchstims/make.py
@@ -9,6 +9,7 @@ import pygame
 
 from .stim_makers import AbstractStimMaker
 from .utils import make_csv
+from .voc import Writer
 
 
 def _generate_xx_and_yy(set_size,
@@ -308,8 +309,10 @@ def make(root_output_dir,
                 if not target_condition_dir.is_dir():
                     target_condition_dir.mkdir()
 
-                def _make_stim(img_num, cells_to_use=None,
-                               xx_to_use_ctr=None, yy_to_use_ctr=None):
+                def _make_stim(img_num,
+                               cells_to_use=None,
+                               xx_to_use_ctr=None,
+                               yy_to_use_ctr=None):
                     """helper function to make and save individual stim
 
                     Define as a nested function so we can avoid repeating ourselves below
@@ -345,12 +348,35 @@ def make(root_output_dir,
                     with open(meta_file, 'w') as fp:
                         json.dump(meta_dict, fp)
 
+                    voc_writer = Writer(
+                        path=abs_path_filename,
+                        width=stim_maker.window_size[1],
+                        height=stim_maker.window_size[0],
+                    )
+                    for voc_object in rect_tuple.voc_objects:
+                        voc_writer.add_object(
+                            name=voc_object.name,
+                            xmin=voc_object.xmin,
+                            ymin=voc_object.ymin,
+                            xmax=voc_object.xmax,
+                            ymax=voc_object.ymax,
+                        )
+                    xml_filename = filename.replace('png', 'xml')
+                    voc_writer.save(
+                        annotation_path=target_condition_dir / xml_filename
+                    )
+                    # use relative path for name of file in csv, as above for img_file
+                    xml_file = Path(stimulus).joinpath(str(set_size),
+                                                       target_condition,
+                                                       xml_filename)
+
                     row = (stimulus,
                            set_size,
                            target_condition,
                            img_num,
                            root_output_dir,
                            img_file,
+                           xml_file,
                            meta_file)
                     rows.append(row)
 

--- a/src/searchstims/stim_makers/RVvRHGVStimMaker.py
+++ b/src/searchstims/stim_makers/RVvRHGVStimMaker.py
@@ -5,6 +5,7 @@ from pygame.rect import Rect
 
 from .abstract_stim_maker import AbstractStimMaker
 from .abstract_stim_maker import colors_dict
+from ..voc import VOCObject
 
 
 class RVvRHGVStimMaker(AbstractStimMaker):
@@ -51,6 +52,7 @@ class RVvRHGVStimMaker(AbstractStimMaker):
         distractor_orientation = list('V' * num_vert_rect + 'H' * num_horz_rect)
         random.shuffle(distractor_orientation)
 
+        voc_objects = []
         for item, (center_x, center_y) in enumerate(zip(xx_to_use_ctr, yy_to_use_ctr)):
             # notice we are now using PyGame order of sizes, (width, height)
             item_bbox_tuple = (0, 0) + (self.item_bbox_size[1], self.item_bbox_size[0])
@@ -64,14 +66,17 @@ class RVvRHGVStimMaker(AbstractStimMaker):
                 target_indices.append(center)
                 if self.grid_size:
                     grid_as_char[cells_to_use[item]] = 't'
+                voc_name = 't'
             else:
                 orientation = distractor_orientation.pop()
                 if orientation == 'V':
                     color = self.distractor_color
                     rotate = False
+                    voc_name = 'dV'
                 elif orientation == 'H':
                     color = self.target_color
                     rotate = True
+                    voc_name = 'dH'
 
                 distractor_indices.append(center)
                 if self.grid_size:
@@ -86,7 +91,15 @@ class RVvRHGVStimMaker(AbstractStimMaker):
                            color=color,
                            rotate=rotate)
 
-        return grid_as_char, target_indices, distractor_indices
+            voc_objects.append(
+                VOCObject(name=voc_name,
+                          xmin=item_bbox.left,
+                          xmax=item_bbox.right,
+                          ymin=item_bbox.bottom,
+                          ymax=item_bbox.top)
+            )
+
+        return grid_as_char, target_indices, distractor_indices, voc_objects
 
     def draw_item(self, display_surface, item_bbox, color, rotate):
         """Draws a vertical rectangle that is 1/3 the width of the item bounding box.

--- a/src/searchstims/stim_makers/TLStimMaker.py
+++ b/src/searchstims/stim_makers/TLStimMaker.py
@@ -6,6 +6,7 @@ from pygame.rect import Rect
 
 from .abstract_stim_maker import AbstractStimMaker
 from .abstract_stim_maker import colors_dict
+from ..voc import VOCObject
 
 THIS_FILE_DIR = Path(__file__).parent
 
@@ -84,6 +85,7 @@ class TLStimMaker(AbstractStimMaker):
         distractor_letters = list('T' * num_distractor_T + 'L' * num_distractor_L)
         random.shuffle(distractor_letters)
 
+        voc_objects = []
         for item, (center_x, center_y) in enumerate(zip(xx_to_use_ctr, yy_to_use_ctr)):
             # notice we are now using PyGame order of sizes, (width, height)
             item_bbox_tuple = (0, 0) + (self.item_bbox_size[1], self.item_bbox_size[0])
@@ -97,13 +99,16 @@ class TLStimMaker(AbstractStimMaker):
                 target_indices.append(center)
                 if self.grid_size:
                     grid_as_char[cells_to_use[item]] = 't'
+                voc_name = 't'
             else:
                 is_target = False
                 distractor_letter = distractor_letters.pop()
                 if distractor_letter == 'T':
                     color = self.distractor_T_color
+                    voc_name = 'dT'
                 elif distractor_letter == 'L':
                     color = self.distractor_L_color
+                    voc_name = 'dL'
                 distractor_indices.append(center)
                 if self.grid_size:
                     grid_as_char[cells_to_use[item]] = distractor_letter
@@ -130,7 +135,15 @@ class TLStimMaker(AbstractStimMaker):
                            item_bbox=item_bbox,
                            to_blit=text_surface_obj)
 
-        return grid_as_char, target_indices, distractor_indices
+            voc_objects.append(
+                VOCObject(name=voc_name,
+                          xmin=item_bbox.left,
+                          xmax=item_bbox.right,
+                          ymin=item_bbox.bottom,
+                          ymax=item_bbox.top)
+            )
+
+        return grid_as_char, target_indices, distractor_indices, voc_objects
 
     def draw_item(self, display_surface, item_bbox, to_blit):
         """Returns target or distractor"""

--- a/src/searchstims/stim_makers/TStimMaker.py
+++ b/src/searchstims/stim_makers/TStimMaker.py
@@ -5,6 +5,7 @@ from pygame.rect import Rect
 
 from .abstract_stim_maker import AbstractStimMaker
 from .abstract_stim_maker import colors_dict
+from ..voc import VOCObject
 
 THIS_FILE_DIR = Path(__file__).parent
 
@@ -49,6 +50,7 @@ class TStimMaker(AbstractStimMaker):
         else:
             grid_as_char = None
 
+        voc_objects = []
         for item, (center_x, center_y) in enumerate(zip(xx_to_use_ctr, yy_to_use_ctr)):
             # notice we are now using PyGame order of sizes, (width, height)
             item_bbox_tuple = (0, 0) + (self.item_bbox_size[1], self.item_bbox_size[0])
@@ -62,12 +64,14 @@ class TStimMaker(AbstractStimMaker):
                 target_indices.append(center)
                 if self.grid_size:
                     grid_as_char[cells_to_use[item]] = 't'
+                name = 't'
             else:
                 is_target = False
                 color = self.distractor_color
                 distractor_indices.append(center)
                 if self.grid_size:
                     grid_as_char[cells_to_use[item]] = 'd'
+                name = 'd'
 
             if type(color) == str:
                 color = colors_dict[color]
@@ -84,7 +88,15 @@ class TStimMaker(AbstractStimMaker):
                            item_bbox=item_bbox,
                            to_blit=text_surface_obj)
 
-        return grid_as_char, target_indices, distractor_indices
+            voc_objects.append(
+                VOCObject(name=name,
+                          xmin=item_bbox.left,
+                          xmax=item_bbox.right,
+                          ymin=item_bbox.bottom,
+                          ymax=item_bbox.top)
+            )
+
+        return grid_as_char, target_indices, distractor_indices, voc_objects
 
     def draw_item(self, display_surface, item_bbox, to_blit):
         """Returns target or distractor"""

--- a/src/searchstims/stim_makers/Two_v_Five_StimMaker.py
+++ b/src/searchstims/stim_makers/Two_v_Five_StimMaker.py
@@ -5,6 +5,7 @@ from pygame.rect import Rect
 
 from .abstract_stim_maker import AbstractStimMaker
 from .abstract_stim_maker import colors_dict
+from ..voc import VOCObject
 
 THIS_FILE_DIR = Path(__file__).parent
 
@@ -52,6 +53,7 @@ class Two_v_Five_StimMaker(AbstractStimMaker):
         else:
             grid_as_char = None
 
+        voc_objects = []
         for item, (center_x, center_y) in enumerate(zip(xx_to_use_ctr, yy_to_use_ctr)):
             # notice we are now using PyGame order of sizes, (width, height)
             item_bbox_tuple = (0, 0) + (self.item_bbox_size[1], self.item_bbox_size[0])
@@ -65,12 +67,14 @@ class Two_v_Five_StimMaker(AbstractStimMaker):
                 target_indices.append(center)
                 if self.grid_size:
                     grid_as_char[cells_to_use[item]] = 't'
+                name = 't'
             else:
                 is_target = False
                 color = self.distractor_color
                 distractor_indices.append(center)
                 if self.grid_size:
                     grid_as_char[cells_to_use[item]] = 'd'
+                name = 'd'
 
             if type(color) == str:
                 color = colors_dict[color]
@@ -90,4 +94,12 @@ class Two_v_Five_StimMaker(AbstractStimMaker):
                            item_bbox=item_bbox,
                            to_blit=text_surface_obj)
 
-        return grid_as_char, target_indices, distractor_indices
+            voc_objects.append(
+                VOCObject(name=name,
+                          xmin=item_bbox.left,
+                          xmax=item_bbox.right,
+                          ymin=item_bbox.bottom,
+                          ymax=item_bbox.top)
+            )
+
+        return grid_as_char, target_indices, distractor_indices, voc_objects

--- a/src/searchstims/stim_makers/xoStimMaker.py
+++ b/src/searchstims/stim_makers/xoStimMaker.py
@@ -6,6 +6,7 @@ from pygame.rect import Rect
 
 from .abstract_stim_maker import AbstractStimMaker
 from .abstract_stim_maker import colors_dict
+from ..voc import VOCObject
 
 THIS_FILE_DIR = Path(__file__).parent
 
@@ -71,6 +72,7 @@ class xoStimMaker(AbstractStimMaker):
         distractor_letters = list('x' * num_distractor_x + 'o' * num_distractor_o)
         random.shuffle(distractor_letters)
 
+        voc_objects = []
         for item, (center_x, center_y) in enumerate(zip(xx_to_use_ctr, yy_to_use_ctr)):
             # notice we are now using PyGame order of sizes, (width, height)
             item_bbox_tuple = (0, 0) + (self.item_bbox_size[1], self.item_bbox_size[0])
@@ -84,16 +86,20 @@ class xoStimMaker(AbstractStimMaker):
                 target_indices.append(center)
                 if self.grid_size:
                     grid_as_char[cells_to_use[item]] = 't'
+                voc_name = 't'
             else:
                 is_target = False
                 distractor_letter = distractor_letters.pop()
                 if distractor_letter == 'x':
                     color = self.distractor_x_color
+                    voc_name = 'dx'
                 elif distractor_letter == 'o':
                     color = self.distractor_o_color
+                    voc_name = 'do'
                 distractor_indices.append(center)
                 if self.grid_size:
                     grid_as_char[cells_to_use[item]] = distractor_letter
+
 
             if type(color) == str:
                 color = colors_dict[color]
@@ -110,7 +116,15 @@ class xoStimMaker(AbstractStimMaker):
                            item_bbox=item_bbox,
                            to_blit=text_surface_obj)
 
-        return grid_as_char, target_indices, distractor_indices
+            voc_objects.append(
+                VOCObject(name=name,
+                          xmin=item_bbox.left,
+                          xmax=item_bbox.right,
+                          ymin=item_bbox.bottom,
+                          ymax=item_bbox.top)
+            )
+
+        return grid_as_char, target_indices, distractor_indices, voc_objects
 
     def draw_item(self, display_surface, item_bbox, to_blit):
         """Returns target or distractor"""

--- a/src/searchstims/utils.py
+++ b/src/searchstims/utils.py
@@ -13,6 +13,7 @@ class SearchStimulus(NamedTuple):
     img_num: int
     root_output_dir: str
     img_file: str
+    xml_file: str
     meta_file: str
 
     @classmethod

--- a/src/searchstims/voc/__init__.py
+++ b/src/searchstims/voc/__init__.py
@@ -1,0 +1,2 @@
+from .object import VOCObject
+from .writer import Writer

--- a/src/searchstims/voc/annotation.xml
+++ b/src/searchstims/voc/annotation.xml
@@ -1,0 +1,26 @@
+<annotation>
+    <folder>{{ folder }}</folder>
+    <filename>{{ filename }}</filename>
+    <path>{{ path }}</path>
+    <source>
+        <database>{{ database }}</database>
+    </source>
+    <size>
+        <width>{{ width }}</width>
+        <height>{{ height }}</height>
+        <depth>{{ depth }}</depth>
+    </size>
+    <segmented>{{ segmented }}</segmented>
+{% for object in objects %}    <object>
+        <name>{{ object.name }}</name>
+        <pose>{{ object.pose }}</pose>
+        <truncated>{{ object.truncated }}</truncated>
+        <difficult>{{ object.difficult }}</difficult>
+        <bndbox>
+            <xmin>{{ object.xmin }}</xmin>
+            <ymin>{{ object.ymin }}</ymin>
+            <xmax>{{ object.xmax }}</xmax>
+            <ymax>{{ object.ymax }}</ymax>
+        </bndbox>
+    </object>{% endfor %}
+</annotation>

--- a/src/searchstims/voc/object.py
+++ b/src/searchstims/voc/object.py
@@ -1,0 +1,13 @@
+from typing import NamedTuple
+
+
+class VOCObject(NamedTuple):
+    """an <object> that appears in the Pascal VOC XML annotation
+
+    used to save Pascal VOC annotations of search displays
+    """
+    name: str
+    xmin: int
+    xmax: int
+    ymin: int
+    ymax: int

--- a/src/searchstims/voc/writer.py
+++ b/src/searchstims/voc/writer.py
@@ -1,0 +1,64 @@
+"""adapted from
+https://github.com/AndrewCarterUK/pascal-voc-writer
+under MIT license
+https://github.com/AndrewCarterUK/pascal-voc-writer/blob/master/LICENSE
+"""
+import os
+from jinja2 import Environment, PackageLoader
+
+
+class Writer:
+    def __init__(self,
+                 path,
+                 width,
+                 height,
+                 depth=3,
+                 database='Unknown',
+                 segmented=0):
+        environment = Environment(
+            loader=PackageLoader(
+                'searchstims',
+                'voc'
+            ),
+            keep_trailing_newline=True
+        )
+        self.annotation_template = environment.get_template('annotation.xml')
+
+        abspath = os.path.abspath(path)
+
+        self.template_parameters = {
+            'path': abspath,
+            'filename': os.path.basename(abspath),
+            'folder': os.path.basename(os.path.dirname(abspath)),
+            'width': width,
+            'height': height,
+            'depth': depth,
+            'database': database,
+            'segmented': segmented,
+            'objects': []
+        }
+
+    def add_object(self,
+                   name,
+                   xmin,
+                   ymin,
+                   xmax,
+                   ymax,
+                   pose='Unspecified',
+                   truncated=0,
+                   difficult=0):
+        self.template_parameters['objects'].append({
+            'name': name,
+            'xmin': xmin,
+            'ymin': ymin,
+            'xmax': xmax,
+            'ymax': ymax,
+            'pose': pose,
+            'truncated': truncated,
+            'difficult': difficult,
+        })
+
+    def save(self, annotation_path):
+        with open(annotation_path, 'w') as file:
+            content = self.annotation_template.render(**self.template_parameters)
+            file.write(content)

--- a/tests/test_data/configs/test_2_v_5_config.ini
+++ b/tests/test_data/configs/test_2_v_5_config.ini
@@ -1,6 +1,6 @@
 [general]
-num_target_present = 100
-num_target_absent = 100
+num_target_present = 30
+num_target_absent = 30
 set_sizes = [1, 2, 4, 6, 8]
 output_dir = ~/output
 csv_filename = filenames_by_set_size_and_target.csv

--- a/tests/test_data/configs/test_RVvGV_config.ini
+++ b/tests/test_data/configs/test_RVvGV_config.ini
@@ -1,6 +1,6 @@
 [general]
-num_target_present = 100
-num_target_absent = 100
+num_target_present = 30
+num_target_absent = 30
 set_sizes = [1, 2, 4, 6, 8]
 output_dir = ~/output
 csv_filename = filenames_by_set_size_and_target.csv

--- a/tests/test_data/configs/test_config_feature_spatial_vgg16.ini
+++ b/tests/test_data/configs/test_config_feature_spatial_vgg16.ini
@@ -1,6 +1,6 @@
 [general]
-num_target_present = 100
-num_target_absent = 100
+num_target_present = 30
+num_target_absent = 30
 set_sizes = [1, 2, 4, 8]
 output_dir = ../visual_search_stimuli/searchstims_feature_spatial_vgg16
 csv_filename = feature_spatial.csv

--- a/tests/test_data/configs/test_config_general_has_common_stim_options.ini
+++ b/tests/test_data/configs/test_config_general_has_common_stim_options.ini
@@ -1,6 +1,6 @@
 [general]
-num_target_present = 100
-num_target_absent = 100
+num_target_present = 30
+num_target_absent = 30
 set_sizes = [1, 2, 4, 8]
 output_dir = ../visual_search_stimuli/searchstims_feature_spatial_vgg16
 csv_filename = feature_spatial.csv

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -2,11 +2,12 @@
 test make module
 """
 import csv
+from glob import glob
 import os
+from pathlib import Path
 import tempfile
 import shutil
 import unittest
-from glob import glob
 
 import imageio
 import numpy as np
@@ -31,10 +32,9 @@ class TestMake(unittest.TestCase):
     def _dirs_got_made(self, config, stim_type):
         for set_size in config.general.set_sizes:
             for target in ('present', 'absent'):
-                dir_that_should_exist = os.path.join(
-                    self.tmp_output_dir, stim_type, str(set_size), target
-                )
-                self.assertTrue(os.path.isdir(dir_that_should_exist))
+                dir_that_should_exist = Path(self.tmp_output_dir) / stim_type / str(set_size) / target
+                self.assertTrue(dir_that_should_exist.exists())
+                self.assertTrue(dir_that_should_exist.is_dir())
         return True
 
     def _files_got_made(self, config, stim_type):
@@ -44,16 +44,15 @@ class TestMake(unittest.TestCase):
                     nums = range(config.general.num_target_present // len(config.general.set_sizes))
                 elif target == 'absent':
                     nums = range(config.general.num_target_absent // len(config.general.set_sizes))
+                parent = Path(self.tmp_output_dir) / stim_type / str(set_size) / target
                 for num in nums:
-                    filename = f'{stim_type}_set_size_{set_size}_target_{target}_{num}.png'
-                    # use absolute path to save
-                    file_that_should_exist = os.path.join(self.tmp_output_dir,
-                                                          stim_type,
-                                                          str(set_size),
-                                                          target,
-                                                          filename)
-
-                    self.assertTrue(os.path.isfile(file_that_should_exist))
+                    stem = f'{stim_type}_set_size_{set_size}_target_{target}_{num}'
+                    for ext in ('png', 'meta.json', 'xml'):
+                        filename = f'{stem}.{ext}'
+                        # use absolute path to save
+                        file_that_should_exist = parent / filename
+                        self.assertTrue(file_that_should_exist.exists())
+                        self.assertTrue(os.path.isfile(file_that_should_exist))
         return True
 
     def _files_got_made_num_target_present_absent_list(self, config, stim_type,
@@ -65,16 +64,15 @@ class TestMake(unittest.TestCase):
                     nums = range(num_imgs_present)
                 elif target == 'absent':
                     nums = range(num_imgs_absent)
+                parent = Path(self.tmp_output_dir) / stim_type / str(set_size) / target
                 for num in nums:
-                    filename = f'{stim_type}_set_size_{set_size}_target_{target}_{num}.png'
-                    # use absolute path to save
-                    file_that_should_exist = os.path.join(self.tmp_output_dir,
-                                                          stim_type,
-                                                          str(set_size),
-                                                          target,
-                                                          filename)
-
-                    self.assertTrue(os.path.isfile(file_that_should_exist))
+                    stem = f'{stim_type}_set_size_{set_size}_target_{target}_{num}'
+                    for ext in ('png', 'meta.json', 'xml'):
+                        filename = f'{stem}.{ext}'
+                        # use absolute path to save
+                        file_that_should_exist = parent / filename
+                        self.assertTrue(file_that_should_exist.exists())
+                        self.assertTrue(os.path.isfile(file_that_should_exist))
         return True
 
     def test_make_RVvGV(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,13 +40,16 @@ class TestUtils(unittest.TestCase):
                             f'{stimulus}_set_size_{set_size}_target_{target_condition}'
                             f'_{img_num}.png'
                         )
+                        xml_file = img_file.replace('png', 'xml')
                         meta_file = img_file.replace('png', 'meta.json')
+
                         row = [stimulus,
                                set_size,
                                target_condition,
                                img_num,
                                root_output_dir,
                                img_file,
+                               xml_file,
                                meta_file]
                         rows.append(row)
 
@@ -69,11 +72,13 @@ class TestUtils(unittest.TestCase):
                         )
                     elif key == 'root_output_dir':
                         self.assertTrue(val == root_output_dir)
-                    elif key == 'img_file' or key == 'meta_file':
+                    elif key == 'img_file' or key == 'xml_file' or key == 'meta_file':
                         stem = (f"{row['stimulus']}_set_size_{row['set_size']}_target_"
                                 f"{row['target_condition']}_{row['img_num']}")
                         if key == 'img_file':
                             self.assertTrue(val == stem + '.png')
+                        elif key == 'xml_file':
+                            self.assertTrue(val == stem + '.xml')
                         elif key == 'meta_file':
                             self.assertTrue(val == stem + '.meta.json')
             expected_num_rows = len(img_nums) * len(to_csv['stimulus']) * \


### PR DESCRIPTION
- add voc/ sub-package with object.py module
- have all StimMakers return RectTuple with list of VOCObjects
  - add `voc_objects` field to `abstract_stim_maker.RectTuple`
  - have the `_make_stim` method of all StimMakers return
    a list of `VOCObject` instances, one for each target +
    distractor in the image
  - this list then becomes the `voc_objects` field in the `RectTuple`
    returned by `make_stim`
  - which the `make` function will use to save Pascal VOC annotation
- DEV: add jinja2 as dependency
- add Writer class to voc sub-package,
  that actually creates Pascal VOC .xml annotations
- modify utils.make_csv so csv will have an xml_file column
- rewrite `make` function to save Pascal VOC .xml file
  for each search display created, and add that file to the csv
- TST: fix `test_utils.test_make_csv` so it correctly
  tests .csv with xml_file column added